### PR TITLE
管理者ページヘッダーの実装

### DIFF
--- a/frontend/server/src/app/(admin)/admin/home/page.tsx
+++ b/frontend/server/src/app/(admin)/admin/home/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { AdminHeader } from "@/components/atoms/layout/AdminHeader";
 import { Button } from "@/components/ui/button";
 import withAuth from "@/hocs/withAuth";
 import { useAuth } from "@/hooks/useAuth";
@@ -9,7 +8,6 @@ export const AdminHome = () => {
   const { logout } = useAuth();
   return (
     <>
-      <AdminHeader />
       <main>
         <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100">
           <div className="container mx-auto px-4 py-8">

--- a/frontend/server/src/app/(admin)/layout.tsx
+++ b/frontend/server/src/app/(admin)/layout.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { AdminHeader } from "@/components/atoms/layout/AdminHeader";
+import { AppSidebar } from "@/components/atoms/sidebar/AppSidebar";
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import type { SidebarGroups } from "@/types/sidebarGroups";
+import { Book, FileType, Home, LogIn, Settings, ShieldQuestion, Users } from "lucide-react";
+import { type ReactNode, memo } from "react";
+
+const sidebarGroups: SidebarGroups[] = [
+  {
+    groupLabel: "メインメニュー",
+    groupItems: [
+      {
+        title: "ホーム",
+        url: "/admin/home",
+        icon: Home,
+      },
+      {
+        title: "コース",
+        url: "/admin/courses",
+        icon: Book,
+      },
+    ],
+  },
+  {
+    groupLabel: "ログ管理",
+    groupItems: [
+      {
+        title: "ログイン履歴",
+        url: "/admin/login-history",
+        icon: LogIn,
+      },
+      {
+        title: "演習問題ログ",
+        url: "/admin/flow-log",
+        icon: FileType,
+      },
+    ],
+  },
+  {
+    groupLabel: "ユーザー設定",
+    groupItems: [
+      {
+        title: "プロフィール",
+        url: "/admin/profile",
+        icon: Users,
+      },
+      {
+        title: "アカウント設定",
+        url: "/admin/account-settings",
+        icon: Settings,
+      },
+    ],
+  },
+  {
+    groupLabel: undefined,
+    groupItems: [
+      {
+        title: "ヘルプ",
+        externalUrl: "/manuals/teacher_manual.pdf",
+        icon: ShieldQuestion, // 適切なアイコンに変更
+        newTab: true,
+      },
+    ],
+  },
+];
+
+export const AdminLayoutInner = memo(({ children }: { children: ReactNode }) => {
+  return (
+    <div className="flex h-screen pt-16">
+      <AppSidebar sidebarGroups={sidebarGroups} />
+      <SidebarInset>
+        <main className="flex-1 w-full">{children}</main>
+      </SidebarInset>
+    </div>
+  );
+});
+
+export const AdminLayout = memo(({ children }: { children: ReactNode }) => {
+  return (
+    <SidebarProvider defaultOpen={false}>
+      <div className="flex flex-col min-h-screen w-full">
+        <AdminHeader />
+        <AdminLayoutInner>{children}</AdminLayoutInner>
+      </div>
+    </SidebarProvider>
+  );
+});
+
+export default AdminLayout;

--- a/frontend/server/src/components/atoms/layout/AdminHeader.tsx
+++ b/frontend/server/src/components/atoms/layout/AdminHeader.tsx
@@ -1,20 +1,26 @@
+"use client";
+
 import { Button } from "@/components/ui/button";
+import { useSidebar } from "@/components/ui/sidebar";
+import { Menu } from "lucide-react";
 import { type FC, memo } from "react";
 
 export const AdminHeader: FC = memo(() => {
+  const { toggleSidebar } = useSidebar();
+
   return (
-    <header className="fixed flex justify-between px-8 w-screen h-16 bg-primary text-primary-foreground items-center drop-shadow-2xl border-b border-gray-300 shadow-md">
-      <Button variant="default">
-        <a
-          href="https://www.notion.so/68ymtlab-fast-api-lms/14a5fee5aec08025bf59f497d42c5ccd"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          マニュアル
-        </a>
+    <header className="fixed flex justify-between px-8 w-screen h-16 bg-primary text-primary-foreground items-center drop-shadow-2xl border-b border-gray-300 shadow-md z-30">
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={() => toggleSidebar()}
+        className="text-primary-foreground hover:bg-primary/80"
+        aria-label="サイドバーの開閉"
+      >
+        <Menu className="size-6" />
       </Button>
       <div className="flex gap-3">
-        <h1 className="font-bold text-2xl">学習支援システム[管理者]</h1>
+        <h1 className="font-bold text-2xl">学習支援システム</h1>
       </div>
     </header>
   );


### PR DESCRIPTION
## issue
Relate #17 
Closes #20 

## 目的
- 管理者ページ全体にヘッダーをつける
- 管理者ホームから仮ヘッダーの削除

## 行ったこと
- app/(admin)/t/layout.tsxの作成
- components/atoms/layout/AdminHeader.tsxの作成
- app/(admin)/t/home/page.tsxの修正

## 実際に試してみるには
- 管理者ユーザーでログインすると表示されます

### その他
- 仮でメニューアイテム作成しているため，まだ確定版ではないです