### PR TITLE
コース選択画面の修正

### DIFF
--- a/frontend/server/package-lock.json
+++ b/frontend/server/package-lock.json
@@ -32,6 +32,7 @@
 				"react-hook-form": "^7.56.3",
 				"react-icons": "^5.5.0",
 				"react-markdown": "^10.1.0",
+				"react-responsive": "^10.0.1",
 				"rehype-mathjax": "^7.1.0",
 				"rehype-raw": "^7.0.0",
 				"rehype-sanitize": "^6.0.0",
@@ -7109,7 +7110,7 @@
 			"version": "19.1.5",
 			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.5.tgz",
 			"integrity": "sha512-CMCjrWucUBZvohgZxkjd6S9h0nZxXjzus6yDfUb+xLxYM7VvjKNH1tQrE9GWLql1XoOP4/Ds3bwFqShHUYraGg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"@types/react": "^19.0.0"
@@ -9792,6 +9793,12 @@
 				}
 			}
 		},
+		"node_modules/css-mediaquery": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
+			"integrity": "sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q==",
+			"license": "BSD"
+		},
 		"node_modules/css-select": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
@@ -11873,12 +11880,6 @@
 				"react-is": "^16.7.0"
 			}
 		},
-		"node_modules/hoist-non-react-statics/node_modules/react-is": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-			"license": "MIT"
-		},
 		"node_modules/homedir-polyfill": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -12022,6 +12023,12 @@
 			"engines": {
 				"node": ">=10.17.0"
 			}
+		},
+		"node_modules/hyphenate-style-name": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
+			"integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/icss-utils": {
 			"version": "5.1.0",
@@ -14407,6 +14414,18 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"license": "MIT",
+			"dependencies": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			},
+			"bin": {
+				"loose-envify": "cli.js"
+			}
+		},
 		"node_modules/loupe": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
@@ -14526,6 +14545,15 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/matchmediaquery": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/matchmediaquery/-/matchmediaquery-0.4.2.tgz",
+			"integrity": "sha512-wrZpoT50ehYOudhDjt/YvUJc6eUzcdFPdmbizfgvswCKNHD1/OBOHYJpHie+HXpu6bSkEGieFMYk6VuutaiRfA==",
+			"license": "MIT",
+			"dependencies": {
+				"css-mediaquery": "^0.1.2"
 			}
 		},
 		"node_modules/math-intrinsics": {
@@ -16705,6 +16733,15 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/object-inspect": {
 			"version": "1.13.4",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -17631,6 +17668,17 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/prop-types": {
+			"version": "15.8.1",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+			"license": "MIT",
+			"dependencies": {
+				"loose-envify": "^1.4.0",
+				"object-assign": "^4.1.1",
+				"react-is": "^16.13.1"
+			}
+		},
 		"node_modules/property-information": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
@@ -17870,6 +17918,12 @@
 				"react": "*"
 			}
 		},
+		"node_modules/react-is": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+			"license": "MIT"
+		},
 		"node_modules/react-markdown": {
 			"version": "10.1.0",
 			"resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
@@ -17952,6 +18006,24 @@
 				"@types/react": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/react-responsive": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-10.0.1.tgz",
+			"integrity": "sha512-OM5/cRvbtUWEX8le8RCT8scA8y2OPtb0Q/IViEyCEM5FBN8lRrkUOZnu87I88A6njxDldvxG+rLBxWiA7/UM9g==",
+			"license": "MIT",
+			"dependencies": {
+				"hyphenate-style-name": "^1.0.0",
+				"matchmediaquery": "^0.4.2",
+				"prop-types": "^15.6.1",
+				"shallow-equal": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0"
 			}
 		},
 		"node_modules/react-style-singleton": {
@@ -18900,6 +18972,12 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/shallow-equal": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-3.1.0.tgz",
+			"integrity": "sha512-pfVOw8QZIXpMbhBWvzBISicvToTiM5WBF1EeAUZDDSb5Dt29yl4AYbyywbJFSEsRUMr7gJaxqCdr4L3tQf9wVg==",
+			"license": "MIT"
+		},
 		"node_modules/sharp": {
 			"version": "0.33.5",
 			"resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
@@ -19699,7 +19777,6 @@
 			"version": "4.1.7",
 			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.7.tgz",
 			"integrity": "sha512-kr1o/ErIdNhTz8uzAYL7TpaUuzKIE6QPQ4qmSdxnoX/lo+5wmUHQA6h3L5yIqEImSRnAAURDirLu/BgiXGPAhg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/tailwindcss-animate": {

--- a/frontend/server/package.json
+++ b/frontend/server/package.json
@@ -35,6 +35,7 @@
 		"react-hook-form": "^7.56.3",
 		"react-icons": "^5.5.0",
 		"react-markdown": "^10.1.0",
+		"react-responsive": "^10.0.1",
 		"rehype-mathjax": "^7.1.0",
 		"rehype-raw": "^7.0.0",
 		"rehype-sanitize": "^6.0.0",

--- a/frontend/server/src/app/(students)/course/[course_id]/page.tsx
+++ b/frontend/server/src/app/(students)/course/[course_id]/page.tsx
@@ -133,7 +133,7 @@ const WeekSelectTable = ({
         </colgroup>
         <thead className="bg-gray-50">
           <tr>
-            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">GROUP</th>
+            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">回</th>
             <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">内容</th>
             <th className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
               教科書コンテンツ
@@ -273,7 +273,7 @@ export const CoursePage = () => {
   const [weeks, setWeeks] = useState<Week[]>([]);
   const [contents, setContents] = useState<Content[]>([]);
   const [loading, setLoading] = useState(true);
-  const [isCardView, setIsCardView] = useState(true);
+  const [isCardView, setIsCardView] = useState(false);
 
   const [groupedWeeksByNum, setGroupedWeeksByNum] = useState<{ [key: number]: Week[] }>({});
   const [expandedWeekNumbers, setExpandedWeekNumbers] = useState<Set<number>>(new Set());
@@ -295,21 +295,6 @@ export const CoursePage = () => {
       setLoading(false);
       return;
     }
-
-    const homeProfile = () => {
-      axios
-        .get("/home_profile")
-        .then((response) => {
-          setUserInfo(response.data);
-        })
-        .catch((error) => {
-          if (error.response?.status === 401) {
-            setSessionError(true);
-          } else {
-            console.log(error.response);
-          }
-        });
-    };
 
     const getCourseInfo = () => {
       axios
@@ -347,7 +332,6 @@ export const CoursePage = () => {
         });
     };
 
-    homeProfile();
     getCourseInfo();
     getWeeksApi();
     getCourseContents();
@@ -389,33 +373,34 @@ export const CoursePage = () => {
   };
 
   const handleMoveWeek = (id: number, isContentId = false) => {
-    if (isContentId) {
-      // 個別コンテンツIDが渡された場合、そのコンテンツページへ遷移
-      const targetContent = contents.find((c) => c.content_id === id);
-      if (targetContent && course_id) {
-        router.push(`/${course_id}/Week/${targetContent.week_id}/${id}`);
-      } else {
-        console.error(`Content with id ${id} not found or course_id missing.`);
-      }
-    } else {
-      // 週IDが渡された場合、その週の最初のコンテンツページへ遷移
-      const weekId = id;
-      const contentsInWeek = contentsMap[weekId];
-      if (contentsInWeek && contentsInWeek.length > 0) {
-        // orderでソートして最初のコンテンツを取得 (すでにソートされている前提だが念のため)
-        const sortedContents = [...contentsInWeek].sort((a, b) => a.order - b.order);
-        const firstContent = sortedContents[0];
-        if (firstContent && course_id) {
-          router.push(`/${course_id}/Week/${weekId}/${firstContent.content_id}`);
-        } else {
-          console.error(`First content in week ${weekId} not found or course_id missing.`);
-        }
-      } else {
-        console.log(`No contents found for week ${weekId}. Cannot start week learning.`);
-        // ここでフォールバックとして週の演習問題ページに飛ばすなども可能
-        // router.push(`/weekflows/${course_id}/${weekId}`);
-      }
-    }
+    // if (isContentId) {
+    //   // 個別コンテンツIDが渡された場合、そのコンテンツページへ遷移
+    //   const targetContent = contents.find((c) => c.content_id === id);
+    //   if (targetContent && course_id) {
+    //     router.push(`/Week/${targetContent.week_id}/${id}`);
+    //   } else {
+    //     console.error(`Content with id ${id} not found or course_id missing.`);
+    //   }
+    // } else {
+    //   // 週IDが渡された場合、その週の最初のコンテンツページへ遷移
+    //   const weekId = id;
+    //   const contentsInWeek = contentsMap[weekId];
+    //   if (contentsInWeek && contentsInWeek.length > 0) {
+    //     // orderでソートして最初のコンテンツを取得 (すでにソートされている前提だが念のため)
+    //     const sortedContents = [...contentsInWeek].sort((a, b) => a.order - b.order);
+    //     const firstContent = sortedContents[0];
+    //     if (firstContent && course_id) {
+    //       router.push(`/${course_id}/Week/${weekId}/${firstContent.content_id}`);
+    //     } else {
+    //       console.error(`First content in week ${weekId} not found or course_id missing.`);
+    //     }
+    //   } else {
+    //     console.log(`No contents found for week ${weekId}. Cannot start week learning.`);
+    //     // ここでフォールバックとして週の演習問題ページに飛ばすなども可能
+    //     // router.push(`/weekflows/${course_id}/${weekId}`);
+    //   }
+    // }
+    router.push(`/lesson/${id}/1`);
   };
 
   const handleMoveFlow = (weekId: number) => {
@@ -425,7 +410,7 @@ export const CoursePage = () => {
   if (sessionError) {
     return (
       <>
-        <main className="pt-16">
+        <main>
           <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100">
             <div className="container mx-auto px-4 py-8">
               <h2 className="text-2xl font-bold text-red-600 mb-4">セッションエラー</h2>
@@ -440,7 +425,7 @@ export const CoursePage = () => {
   if (loading) {
     return (
       <>
-        <main className="pt-16">
+        <main>
           <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100">
             <div className="container mx-auto px-4 py-8">
               <p>読み込み中...</p>
@@ -453,7 +438,7 @@ export const CoursePage = () => {
 
   return (
     <>
-      <main className="pt-16">
+      <main>
         <div className="min-h-screen bg-gray-100">
           <div className="container mx-auto px-4 py-8">
             <div className="max-w-6xl mx-auto">
@@ -470,13 +455,13 @@ export const CoursePage = () => {
                 <div className="flex items-center justify-end space-x-4">
                   <div className="flex items-center space-x-2">
                     <svg className="w-6 h-6 text-gray-600" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                      <title>カード表示アイコン</title>
-                      <path d="M4 6H2v14c0 1.1.9 2 2 2h14v-2H4V6zm16-4H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-1 9H9V9h10v2zm-4 4H9v-2h6v2zm4-8H9V5h10v2z" />
+                      <title>リスト表示アイコン</title>
+                      <path d="M3 13h2v-2H3v2zm0 4h2v-2H3v2zm0-8h2V7H3v2zm4 4h14v-2H7v2zm0 4h14v-2H7v2zM7 7v2h14V7H7z" />
                     </svg>
                     <CustomSwitch checked={isCardView} onCheckedChange={setIsCardView} />
                     <svg className="w-6 h-6 text-gray-600" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                      <title>リスト表示アイコン</title>
-                      <path d="M3 13h2v-2H3v2zm0 4h2v-2H3v2zm0-8h2V7H3v2zm4 4h14v-2H7v2zm0 4h14v-2H7v2zM7 7v2h14V7H7z" />
+                      <title>カード表示アイコン</title>
+                      <path d="M4 6H2v14c0 1.1.9 2 2 2h14v-2H4V6zm16-4H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-1 9H9V9h10v2zm-4 4H9v-2h6v2zm4-8H9V5h10v2z" />
                     </svg>
                   </div>
                 </div>

--- a/frontend/server/src/app/(students)/home/page.tsx
+++ b/frontend/server/src/app/(students)/home/page.tsx
@@ -26,6 +26,7 @@ import {
   Trophy,
   User,
 } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 
 interface Course {
@@ -56,6 +57,7 @@ interface HighPointer {
 }
 
 export const StudentHome = () => {
+  const router = useRouter();
   const { logout } = useAuth();
   const [username, setUsername] = useState("");
   const [point, setPoint] = useState("0");
@@ -455,7 +457,11 @@ export const StudentHome = () => {
                       </div>
                     </CardContent>
                     <CardFooter className="flex gap-3">
-                      <Button className="flex-1 h-11" variant="default">
+                      <Button
+                        className="flex-1 h-11"
+                        variant="default"
+                        onClick={() => router.push(`/course/${subject.id}`)}
+                      >
                         <Play className="w-5 h-5 mr-2" />
                         学習を始める
                       </Button>

--- a/frontend/server/src/app/(students)/lesson/[lesson_id]/[page]/page.tsx
+++ b/frontend/server/src/app/(students)/lesson/[lesson_id]/[page]/page.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { MathJax } from "@/components/shared/MathJax";
+import axios from "@/lib/axios";
+import { useParams, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useMediaQuery } from "react-responsive";
+
+export const LessonPage = () => {
+  const isMobile = useMediaQuery({ query: "(max-width: 768px)" });
+  const router = useRouter();
+  const params = useParams();
+  const lesson_id = params.lesson_id as string;
+  const page = params.page as string;
+
+  const [lesson, setLesson] = useState(null);
+  const [content, setContent] = useState<string>("");
+
+  const getLessonContent = async (page: string) => {
+    const response = await axios.get(`/get_week_content/${lesson_id}/${page}`);
+    console.log(response.data);
+    setLesson(response.data);
+    setContent(response.data.content);
+  };
+
+  useEffect(() => {
+    getLessonContent(page);
+  }, [page]);
+
+  return (
+    <>
+      {isMobile ? (
+        <div className="flex flex-col">
+          <h1>
+            Lesson {lesson_id} {page}
+          </h1>
+          <MathJax text={content} />
+        </div>
+      ) : (
+        <div className="container">
+          <h1>
+            Lesson {lesson_id} {page}
+          </h1>
+          <MathJax text={content} />
+        </div>
+      )}
+    </>
+  );
+};
+
+export default LessonPage;

--- a/frontend/server/src/app/globals.css
+++ b/frontend/server/src/app/globals.css
@@ -134,9 +134,9 @@ html[data-theme="theme3"] {
 }
 
 html[data-theme="theme4"] {
-	--primary: oklch(88% 0.16 105);         /* より黄色らしい、フレッシュな色 */
-	--primary-foreground: oklch(20% 0 0);   /* 黒に近い文字色 */
-	--secondary: oklch(95% 0.08 105);       /* 明るめサブカラー */
+	--primary: oklch(88% 0.16 105); /* より黄色らしい、フレッシュな色 */
+	--primary-foreground: oklch(20% 0 0); /* 黒に近い文字色 */
+	--secondary: oklch(95% 0.08 105); /* 明るめサブカラー */
 	--secondary-foreground: oklch(30% 0 0);
 }
 
@@ -182,4 +182,39 @@ html[data-theme="theme9"] {
 	body {
 		@apply bg-background text-foreground;
 	}
+	h1 {
+		font-size: 2em;
+		font-weight: bold;
+		margin: 10px 0;
+	}
+	h2 {
+		font-size: 1.5em;
+		font-weight: bold;
+		margin: 12px 0;
+	}
+	h3 {
+		font-size: 1.17em;
+		font-weight: bold;
+		margin: 12px 0;
+	}
+	h4 {
+		font-size: 1em;
+		font-weight: bold;
+		margin: 12px 0;
+	}
+	h5 {
+		font-size: 0.83em;
+		font-weight: bold;
+		margin: 12px 0;
+	}
+	h6 {
+		font-size: 0.67em;
+		font-weight: bold;
+		margin: 12px 0;
+	}
+}
+
+.container {
+	margin: 0 auto;
+	width: 1200px;
 }


### PR DESCRIPTION
## issue
Relate #45 
Closes #39 

## 目的
学生画面のコース選択画面の修正

## 行ったこと
- ホームからコース選択画面へのボタン遷移（仮）
- コース選択画面から教科書コンテンツへの遷移（仮）
- カード表示アイコンとリスト表示アイコンが逆になっていたため修正
- h1～h6が動作するように調整

## 実際に試してみるには
- `/home` の学習科目一覧の「学習を始める」からコース選択画面への遷移
- `/course/{course_id}` の教科書コンテンツの「学習を始める」から教科書コンテンツ画面への遷移（未作成のためNotFound）
- `/course/{course_id}` のカード表示アイコンとリスト表示アイコンがあっているかの確認

### その他
