### PR TITLE
教師用・コース選択_科目選択画面の作成

### DIFF
--- a/frontend/server/src/app/(students)/course/[course_id]/page.tsx
+++ b/frontend/server/src/app/(students)/course/[course_id]/page.tsx
@@ -267,7 +267,7 @@ export const CoursePage = () => {
   const router = useRouter();
   const course_id = params.course_id as string;
 
-  const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
+  const [_userInfo, setUserInfo] = useState<UserInfo | null>(null);
   const [sessionError, setSessionError] = useState(false);
   const [course, setCourse] = useState<Course | null>(null);
   const [weeks, setWeeks] = useState<Week[]>([]);
@@ -306,7 +306,6 @@ export const CoursePage = () => {
           if (error.response?.status === 401) {
             setSessionError(true);
           } else {
-            console.log(error.response);
           }
         });
     };
@@ -411,7 +410,6 @@ export const CoursePage = () => {
           console.error(`First content in week ${weekId} not found or course_id missing.`);
         }
       } else {
-        console.log(`No contents found for week ${weekId}. Cannot start week learning.`);
         // ここでフォールバックとして週の演習問題ページに飛ばすなども可能
         // router.push(`/weekflows/${course_id}/${weekId}`);
       }
@@ -486,7 +484,7 @@ export const CoursePage = () => {
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                   {Object.entries(groupedWeeksByNum)
                     .sort(([numA], [numB]) => Number.parseInt(numA) - Number.parseInt(numB))
-                    .flatMap(([weekNum, weeksInGroup]) =>
+                    .flatMap(([_weekNum, weeksInGroup]) =>
                       weeksInGroup.map((week) => (
                         <WeekSelectCard
                           key={week.week_id}
@@ -499,7 +497,7 @@ export const CoursePage = () => {
                     ).length > 0 ? (
                     Object.entries(groupedWeeksByNum)
                       .sort(([numA], [numB]) => Number.parseInt(numA) - Number.parseInt(numB))
-                      .flatMap(([weekNum, weeksInGroup]) =>
+                      .flatMap(([_weekNum, weeksInGroup]) =>
                         weeksInGroup.map((week) => (
                           <WeekSelectCard
                             key={week.week_id}

--- a/frontend/server/src/app/(students)/weekflows/[course_id]/[week_id]/page.tsx
+++ b/frontend/server/src/app/(students)/weekflows/[course_id]/[week_id]/page.tsx
@@ -38,7 +38,7 @@ export const WeekFlowsPage = () => {
 
   const [week, setWeek] = useState<Week | null>(null);
   const [flows, setFlows] = useState<Flow[]>([]);
-  const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
+  const [_userInfo, setUserInfo] = useState<UserInfo | null>(null);
   const [sessionError, setSessionError] = useState(false);
   const [loading, setLoading] = useState(true);
 
@@ -59,7 +59,6 @@ export const WeekFlowsPage = () => {
           if (error.response?.status === 401) {
             setSessionError(true);
           } else {
-            console.log(error.response);
           }
         });
     };
@@ -94,9 +93,7 @@ export const WeekFlowsPage = () => {
     getWeekFlows();
   }, [course_id, week_id]);
 
-  const handleStartFlow = (flowId: number) => {
-    // 演習問題開始の処理
-    console.log(`演習問題 ${flowId} を開始します`);
+  const handleStartFlow = (_flowId: number) => {
     // ここで実際の演習問題ページに遷移する処理を実装
   };
 

--- a/frontend/server/src/app/(teacher)/t/course/[course_id]/page.tsx
+++ b/frontend/server/src/app/(teacher)/t/course/[course_id]/page.tsx
@@ -1,0 +1,723 @@
+"use client";
+import { TeacherHeader } from "@/components/atoms/layout/TeacherHeader";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import withAuth from "@/hocs/withAuth";
+import axios from "@/lib/axios";
+import { BarChart2, Edit, Eye, Loader2 } from "lucide-react";
+import { useParams, useRouter } from "next/navigation";
+import React, { useState, useEffect } from "react";
+
+interface UserInfo {
+  id: number;
+  name: string;
+  email: string;
+  username: string;
+  kind_name: string;
+}
+
+interface Course {
+  course_id: number;
+  subject_name: string;
+  course_name: string;
+  period: string;
+  course_description?: string;
+  year: string;
+  semester: string;
+}
+
+interface Week {
+  week_id: number;
+  week_name: string;
+  week_num: number;
+  order: number;
+}
+
+interface Content {
+  content_id: number;
+  content_name: string;
+  week_id: number;
+  order: number;
+}
+
+// カスタムスイッチコンポーネント
+const CustomSwitch = ({
+  checked,
+  onCheckedChange,
+}: {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}) => (
+  <label className="relative inline-flex items-center cursor-pointer">
+    <input type="checkbox" checked={checked} onChange={(e) => onCheckedChange(e.target.checked)} className="sr-only" />
+    <div className={`w-11 h-6 rounded-full transition-colors ${checked ? "bg-blue-600" : "bg-gray-300"}`}>
+      <div
+        className={`w-5 h-5 bg-white rounded-full shadow-md transform transition-transform ${
+          checked ? "translate-x-5" : "translate-x-0"
+        } mt-0.5 ml-0.5`}
+      />
+    </div>
+  </label>
+);
+
+// 週選択カードコンポーネント
+const WeekSelectCard = ({
+  week,
+  contents,
+  onMoveWeek,
+  onMoveFlow,
+}: {
+  week: Week;
+  contents: Content[];
+  onMoveWeek: (id: number, isContentId?: boolean) => void;
+  onMoveFlow: (weekId: number) => void;
+}) => {
+  const [loadingButtons, setLoadingButtons] = useState<{ [key: string]: boolean }>({});
+
+  const handleButtonClick = async (buttonId: string, callback: () => Promise<void> | void) => {
+    setLoadingButtons((prev) => ({ ...prev, [buttonId]: true }));
+    try {
+      await callback();
+    } finally {
+      setTimeout(() => {
+        setLoadingButtons((prev) => ({ ...prev, [buttonId]: false }));
+      }, 500);
+    }
+  };
+
+  return (
+    <Card className="h-full hover:shadow-lg transition-shadow duration-200 border border-gray-100">
+      <CardContent className="p-6">
+        <div className="flex items-center gap-2 mb-3">
+          <div className="bg-primary/10 text-primary px-3 py-1 rounded-full text-sm font-medium">
+            第{week.week_num}回
+          </div>
+        </div>
+        <h3 className="text-lg font-semibold mb-4 text-gray-800">{week.week_name}</h3>
+
+        {contents.length > 0 && (
+          <div className="space-y-2 mb-4">
+            <h4 className="text-sm font-medium text-gray-700 mb-2">コンテンツ:</h4>
+            {contents.map((content) => (
+              <div
+                key={content.content_id}
+                className="flex items-center justify-between p-3 bg-gray-50 rounded-lg text-sm hover:bg-gray-100 transition-colors duration-200"
+              >
+                <span className="text-gray-700">{content.content_name}</span>
+                <div className="flex gap-2">
+                  <Button
+                    variant="default"
+                    size="sm"
+                    onClick={() =>
+                      handleButtonClick(`preview-content-${content.content_id}`, () =>
+                        onMoveWeek(content.content_id, true),
+                      )
+                    }
+                    className="text-xs bg-primary text-white hover:bg-primary/90"
+                    disabled={loadingButtons[`preview-content-${content.content_id}`]}
+                  >
+                    {loadingButtons[`preview-content-${content.content_id}`] ? (
+                      <Loader2 className="w-3 h-3 animate-spin" />
+                    ) : (
+                      <>
+                        <Eye className="w-3 h-3 mr-1" />
+                        プレビュー
+                      </>
+                    )}
+                  </Button>
+                  <Button
+                    variant="default"
+                    size="sm"
+                    onClick={() =>
+                      handleButtonClick(`edit-content-${content.content_id}`, () =>
+                        onMoveWeek(content.content_id, true),
+                      )
+                    }
+                    className="text-xs bg-primary text-white hover:bg-primary/90"
+                    disabled={loadingButtons[`edit-content-${content.content_id}`]}
+                  >
+                    {loadingButtons[`edit-content-${content.content_id}`] ? (
+                      <Loader2 className="w-3 h-3 animate-spin" />
+                    ) : (
+                      <>
+                        <Edit className="w-3 h-3 mr-1" />
+                        編集
+                      </>
+                    )}
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className="flex space-x-2 mt-4">
+          <Button
+            variant="default"
+            onClick={() => handleButtonClick(`preview-${week.week_id}`, () => onMoveWeek(week.week_id))}
+            className="flex-1 bg-primary text-white hover:bg-primary/90 font-medium py-2 rounded-xl transition-all text-sm flex items-center justify-center gap-2"
+            disabled={loadingButtons[`preview-${week.week_id}`]}
+          >
+            {loadingButtons[`preview-${week.week_id}`] ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <>
+                <Eye className="w-4 h-4" />
+                プレビュー
+              </>
+            )}
+          </Button>
+          <Button
+            variant="default"
+            onClick={() => handleButtonClick(`edit-${week.week_id}`, () => onMoveWeek(week.week_id))}
+            className="flex-1 bg-primary text-white hover:bg-primary/90 font-medium py-2 rounded-xl transition-shadow hover:shadow-xl text-sm flex items-center justify-center gap-2"
+            disabled={loadingButtons[`edit-${week.week_id}`]}
+          >
+            {loadingButtons[`edit-${week.week_id}`] ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <>
+                <Edit className="w-4 h-4" />
+                編集
+              </>
+            )}
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() => handleButtonClick(`status-${week.week_id}`, () => onMoveFlow(week.week_id))}
+            className="flex-1 border-primary/20 text-primary hover:bg-primary/5 font-medium py-2 rounded-xl transition-all text-sm flex items-center justify-center gap-2"
+            disabled={loadingButtons[`status-${week.week_id}`]}
+          >
+            {loadingButtons[`status-${week.week_id}`] ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <>
+                <BarChart2 className="w-4 h-4" />
+                学習状況
+              </>
+            )}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+// 週選択テーブルコンポーネント
+const WeekSelectTable = ({
+  groupedWeeks,
+  contentsMap,
+  expandedWeekNumbers,
+  onToggleWeekNumber,
+  onMoveWeek,
+  onMoveFlow,
+}: {
+  groupedWeeks: { [key: number]: Week[] };
+  contentsMap: { [weekId: number]: Content[] };
+  expandedWeekNumbers: Set<number>;
+  onToggleWeekNumber: (weekNum: number) => void;
+  onMoveWeek: (id: number, isContentId?: boolean) => void;
+  onMoveFlow: (weekId: number) => void;
+}) => {
+  const [loadingButtons, setLoadingButtons] = useState<{ [key: string]: boolean }>({});
+
+  const handleButtonClick = async (buttonId: string, callback: () => Promise<void> | void) => {
+    setLoadingButtons((prev) => ({ ...prev, [buttonId]: true }));
+    try {
+      await callback();
+    } finally {
+      setTimeout(() => {
+        setLoadingButtons((prev) => ({ ...prev, [buttonId]: false }));
+      }, 500);
+    }
+  };
+
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
+      <div className="overflow-x-auto relative">
+        <table className="w-full table-layout-fixed">
+          <colgroup>
+            <col className="w-1/5" />
+            <col className="w-2/5" />
+            <col className="w-1/5" />
+            <col className="w-1/5" />
+            <col className="w-1/5" />
+          </colgroup>
+          <thead className="bg-gray-50 sticky top-0 z-10">
+            <tr>
+              <th className="px-6 py-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">GROUP</th>
+              <th className="px-6 py-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">内容</th>
+              <th className="px-6 py-4 text-center text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">
+                プレビュー
+              </th>
+              <th className="px-6 py-4 text-center text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">
+                編集
+              </th>
+              <th className="px-6 py-4 text-center text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">
+                学習状況
+              </th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {Object.entries(groupedWeeks)
+              .sort(([numA], [numB]) => Number.parseInt(numA) - Number.parseInt(numB))
+              .map(([weekNumStr, weeksInGroup]) => {
+                const weekNum = Number.parseInt(weekNumStr);
+                const isGroupExpanded = expandedWeekNumbers.has(weekNum);
+
+                return (
+                  <React.Fragment key={`group-${weekNum}`}>
+                    <tr className="bg-gray-50 hover:bg-gray-100 transition-colors duration-200">
+                      <td className="p-0" colSpan={5}>
+                        <button
+                          type="button"
+                          onClick={() => onToggleWeekNumber(weekNum)}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter" || e.key === " ") {
+                              e.preventDefault();
+                              onToggleWeekNumber(weekNum);
+                            }
+                          }}
+                          className="w-full flex items-center space-x-2 px-6 py-4 text-left text-sm font-semibold text-primary whitespace-nowrap hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-primary cursor-pointer"
+                        >
+                          <svg
+                            className={`w-5 h-5 transition-transform transform ${isGroupExpanded ? "rotate-90" : ""}`}
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                            aria-hidden="true"
+                          >
+                            <title>開閉アイコン</title>
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 5l7 7-7 7" />
+                          </svg>
+                          <span>第{weekNum}回</span>
+                        </button>
+                      </td>
+                    </tr>
+
+                    {isGroupExpanded &&
+                      weeksInGroup.map((week) => {
+                        const individualContents = contentsMap[week.week_id] || [];
+                        individualContents.sort((a, b) => a.order - b.order);
+
+                        return (
+                          <React.Fragment key={week.week_id}>
+                            <tr className="border-t bg-white hover:bg-gray-50 transition-colors duration-200">
+                              <td className="pl-10 pr-6 py-4 text-sm text-gray-500" />
+                              <td className="px-6 py-4 text-base font-medium text-gray-700">{week.week_name}</td>
+                              <td className="px-6 py-4 text-center text-sm">
+                                <Button
+                                  variant="default"
+                                  size="sm"
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    handleButtonClick(`preview-${week.week_id}`, () => onMoveWeek(week.week_id));
+                                  }}
+                                  className="bg-primary text-white hover:bg-primary/90"
+                                  disabled={loadingButtons[`preview-${week.week_id}`]}
+                                >
+                                  {loadingButtons[`preview-${week.week_id}`] ? (
+                                    <Loader2 className="w-4 h-4 animate-spin" />
+                                  ) : (
+                                    <>
+                                      <Eye className="w-4 h-4 mr-1" />
+                                      プレビュー
+                                    </>
+                                  )}
+                                </Button>
+                              </td>
+                              <td className="px-6 py-4 text-center text-sm">
+                                <Button
+                                  variant="default"
+                                  size="sm"
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    handleButtonClick(`edit-${week.week_id}`, () => onMoveWeek(week.week_id));
+                                  }}
+                                  className="bg-primary text-white hover:bg-primary/90"
+                                  disabled={loadingButtons[`edit-${week.week_id}`]}
+                                >
+                                  {loadingButtons[`edit-${week.week_id}`] ? (
+                                    <Loader2 className="w-4 h-4 animate-spin" />
+                                  ) : (
+                                    <>
+                                      <Edit className="w-4 h-4 mr-1" />
+                                      編集
+                                    </>
+                                  )}
+                                </Button>
+                              </td>
+                              <td className="px-6 py-4 text-center text-sm">
+                                <Button
+                                  variant="outline"
+                                  size="sm"
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    handleButtonClick(`status-${week.week_id}`, () => onMoveFlow(week.week_id));
+                                  }}
+                                  className="border-primary/20 text-primary hover:bg-primary/5"
+                                  disabled={loadingButtons[`status-${week.week_id}`]}
+                                >
+                                  {loadingButtons[`status-${week.week_id}`] ? (
+                                    <Loader2 className="w-4 h-4 animate-spin" />
+                                  ) : (
+                                    <>
+                                      <BarChart2 className="w-4 h-4 mr-1" />
+                                      学習状況
+                                    </>
+                                  )}
+                                </Button>
+                              </td>
+                            </tr>
+
+                            {individualContents.map((content) => (
+                              <tr
+                                key={content.content_id}
+                                className="bg-gray-50 hover:bg-gray-100 transition-colors duration-200"
+                              >
+                                <td className="pl-10 pr-6 py-4 whitespace-nowrap text-sm text-gray-500" />
+                                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-700">
+                                  {content.content_name}
+                                </td>
+                                <td className="px-6 py-4 whitespace-nowrap text-center text-sm">
+                                  <Button
+                                    variant="default"
+                                    size="sm"
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      handleButtonClick(`preview-content-${content.content_id}`, () =>
+                                        onMoveWeek(content.content_id, true),
+                                      );
+                                    }}
+                                    className="bg-primary text-white hover:bg-primary/90"
+                                    disabled={loadingButtons[`preview-content-${content.content_id}`]}
+                                  >
+                                    {loadingButtons[`preview-content-${content.content_id}`] ? (
+                                      <Loader2 className="w-4 h-4 animate-spin" />
+                                    ) : (
+                                      <>
+                                        <Eye className="w-4 h-4 mr-1" />
+                                        プレビュー
+                                      </>
+                                    )}
+                                  </Button>
+                                </td>
+                                <td className="px-6 py-4 whitespace-nowrap text-center text-sm">
+                                  <Button
+                                    variant="default"
+                                    size="sm"
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      handleButtonClick(`edit-content-${content.content_id}`, () =>
+                                        onMoveWeek(content.content_id, true),
+                                      );
+                                    }}
+                                    className="bg-primary text-white hover:bg-primary/90"
+                                    disabled={loadingButtons[`edit-content-${content.content_id}`]}
+                                  >
+                                    {loadingButtons[`edit-content-${content.content_id}`] ? (
+                                      <Loader2 className="w-4 h-4 animate-spin" />
+                                    ) : (
+                                      <>
+                                        <Edit className="w-4 h-4 mr-1" />
+                                        編集
+                                      </>
+                                    )}
+                                  </Button>
+                                </td>
+                                <td className="px-6 py-4 whitespace-nowrap text-center text-sm text-gray-500">-</td>
+                              </tr>
+                            ))}
+                          </React.Fragment>
+                        );
+                      })}
+                  </React.Fragment>
+                );
+              })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export const CoursePage = () => {
+  const params = useParams();
+  const router = useRouter();
+  const course_id = params.course_id as string;
+
+  const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
+  const [sessionError, setSessionError] = useState(false);
+  const [course, setCourse] = useState<Course | null>(null);
+  const [weeks, setWeeks] = useState<Week[]>([]);
+  const [contents, setContents] = useState<Content[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [isCardView, setIsCardView] = useState(false);
+
+  const [groupedWeeksByNum, setGroupedWeeksByNum] = useState<{ [key: number]: Week[] }>({});
+  const [expandedWeekNumbers, setExpandedWeekNumbers] = useState<Set<number>>(new Set());
+
+  const contentsMap = contents.reduce(
+    (acc, content) => {
+      if (!acc[content.week_id]) {
+        acc[content.week_id] = [];
+      }
+      acc[content.week_id].push(content);
+      return acc;
+    },
+    {} as { [weekId: number]: Content[] },
+  );
+
+  useEffect(() => {
+    if (!course_id) {
+      setLoading(false);
+      return;
+    }
+
+    const homeProfile = () => {
+      axios
+        .get("/home_profile")
+        .then((response) => {
+          setUserInfo(response.data);
+        })
+        .catch((error) => {
+          if (error.response?.status === 401) {
+            setSessionError(true);
+          } else {
+            console.log(error.response);
+          }
+        });
+    };
+
+    const getCourseInfo = () => {
+      axios
+        .get(`/get_course_info/${course_id}`)
+        .then((response) => {
+          setCourse(response.data);
+        })
+        .catch((error) => {
+          console.error("コース情報の取得に失敗しました:", error);
+        });
+    };
+
+    const getWeeksApi = () => {
+      axios
+        .get(`/get_weeks/${course_id}`)
+        .then((response) => {
+          setWeeks(response.data);
+        })
+        .catch((error) => {
+          console.error("週一覧の取得に失敗しました:", error);
+        });
+    };
+
+    const getCourseContents = () => {
+      axios
+        .get(`/get_course_contents/${course_id}`)
+        .then((response) => {
+          setContents(response.data);
+        })
+        .catch((error) => {
+          console.error("コンテンツ一覧の取得に失敗しました:", error);
+        })
+        .finally(() => {
+          setLoading(false);
+        });
+    };
+
+    homeProfile();
+    getCourseInfo();
+    getWeeksApi();
+    getCourseContents();
+  }, [course_id]);
+
+  useEffect(() => {
+    if (weeks.length > 0) {
+      const groups = weeks.reduce(
+        (acc, week) => {
+          const key = week.week_num;
+          if (!acc[key]) {
+            acc[key] = [];
+          }
+          acc[key].push(week);
+          return acc;
+        },
+        {} as { [key: number]: Week[] },
+      );
+
+      for (const numKey in groups) {
+        groups[numKey].sort((a, b) => a.order - b.order);
+      }
+      setGroupedWeeksByNum(groups);
+    } else {
+      setGroupedWeeksByNum({});
+    }
+  }, [weeks]);
+
+  const handleToggleWeekNumber = (weekNum: number) => {
+    const newExpanded = new Set(expandedWeekNumbers);
+    if (newExpanded.has(weekNum)) {
+      newExpanded.delete(weekNum);
+    } else {
+      newExpanded.add(weekNum);
+    }
+    setExpandedWeekNumbers(newExpanded);
+  };
+
+  const handleMoveWeek = (id: number, isContentId = false) => {
+    if (isContentId) {
+      const targetContent = contents.find((c) => c.content_id === id);
+      if (targetContent && course_id) {
+        router.push(`/t/course/${course_id}/Week/${targetContent.week_id}/${id}`);
+      } else {
+        console.error(`Content with id ${id} not found or course_id missing.`);
+      }
+    } else {
+      const weekId = id;
+      const contentsInWeek = contentsMap[weekId];
+      if (contentsInWeek && contentsInWeek.length > 0) {
+        const sortedContents = [...contentsInWeek].sort((a, b) => a.order - b.order);
+        const firstContent = sortedContents[0];
+        if (firstContent && course_id) {
+          router.push(`/t/course/${course_id}/Week/${weekId}/${firstContent.content_id}`);
+        } else {
+          console.error(`First content in week ${weekId} not found or course_id missing.`);
+        }
+      } else {
+        console.log(`No contents found for week ${weekId}. Cannot start week learning.`);
+      }
+    }
+  };
+
+  const handleMoveFlow = (weekId: number) => {
+    router.push(`/t/weekflows/${course_id}/${weekId}`);
+  };
+
+  if (sessionError) {
+    return (
+      <>
+        <main className="pt-16">
+          <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100">
+            <div className="container mx-auto px-4 py-8">
+              <h2 className="text-2xl font-bold text-red-600 mb-4">セッションエラー</h2>
+              <p>ログインが必要です。</p>
+            </div>
+          </div>
+        </main>
+      </>
+    );
+  }
+
+  if (loading) {
+    return (
+      <>
+        <main className="pt-16">
+          <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100">
+            <div className="container mx-auto px-4 py-8">
+              <p>読み込み中...</p>
+            </div>
+          </div>
+        </main>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <TeacherHeader />
+      <main className="pt-16">
+        <div className="min-h-screen bg-gradient-to-b from-gray-50 to-gray-100">
+          <div className="container mx-auto px-4 py-8">
+            <div className="max-w-6xl mx-auto">
+              {course && (
+                <div className="mb-8 bg-white rounded-xl p-6 shadow-sm border border-gray-100">
+                  <div className="flex items-center gap-3 mb-2">
+                    <h1 className="text-3xl font-bold text-primary">{course.subject_name}</h1>
+                    <span className="bg-blue-100 text-blue-800 text-sm font-medium px-3 py-1 rounded-full">必修</span>
+                    <span className="bg-purple-100 text-purple-800 text-sm font-medium px-3 py-1 rounded-full">
+                      基礎
+                    </span>
+                  </div>
+                  <h2 className="text-xl text-gray-600 mb-4">
+                    {course.course_name} / {course.period}
+                  </h2>
+                  {course.course_description && (
+                    <blockquote className="text-gray-600 mt-4 p-4 bg-gray-50 rounded-lg border-l-4 border-primary">
+                      <p className="italic">{course.course_description}</p>
+                    </blockquote>
+                  )}
+                </div>
+              )}
+
+              <div className="mb-6">
+                <div className="flex items-center justify-end space-x-4">
+                  <div className="flex items-center space-x-2 bg-white p-2 rounded-lg shadow-sm border border-gray-100">
+                    <svg className="w-6 h-6 text-primary" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                      <title>カード表示アイコン</title>
+                      <path d="M4 6H2v14c0 1.1.9 2 2 2h14v-2H4V6zm16-4H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-1 9H9V9h10v2zm-4 4H9v-2h6v2zm4-8H9V5h10v2z" />
+                    </svg>
+                    <CustomSwitch checked={isCardView} onCheckedChange={setIsCardView} />
+                    <svg className="w-6 h-6 text-primary" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                      <title>リスト表示アイコン</title>
+                      <path d="M3 13h2v-2H3v2zm0 4h2v-2H3v2zm0-8h2V7H3v2zm4 4h14v-2H7v2zm0 4h14v-2H7v2zM7 7v2h14V7H7z" />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+
+              {isCardView && (
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                  {Object.entries(groupedWeeksByNum)
+                    .sort(([numA], [numB]) => Number.parseInt(numA) - Number.parseInt(numB))
+                    .flatMap(([weekNum, weeksInGroup]) =>
+                      weeksInGroup.map((week) => (
+                        <WeekSelectCard
+                          key={week.week_id}
+                          week={week}
+                          contents={contentsMap[week.week_id] || []}
+                          onMoveWeek={handleMoveWeek}
+                          onMoveFlow={handleMoveFlow}
+                        />
+                      )),
+                    ).length > 0 ? (
+                    Object.entries(groupedWeeksByNum)
+                      .sort(([numA], [numB]) => Number.parseInt(numA) - Number.parseInt(numB))
+                      .flatMap(([weekNum, weeksInGroup]) =>
+                        weeksInGroup.map((week) => (
+                          <WeekSelectCard
+                            key={week.week_id}
+                            week={week}
+                            contents={contentsMap[week.week_id] || []}
+                            onMoveWeek={handleMoveWeek}
+                            onMoveFlow={handleMoveFlow}
+                          />
+                        )),
+                      )
+                  ) : (
+                    <div className="col-span-full bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+                      <p className="text-center text-gray-500">このコースには週が設定されていません。</p>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {!isCardView && (
+                <WeekSelectTable
+                  groupedWeeks={groupedWeeksByNum}
+                  contentsMap={contentsMap}
+                  expandedWeekNumbers={expandedWeekNumbers}
+                  onToggleWeekNumber={handleToggleWeekNumber}
+                  onMoveWeek={handleMoveWeek}
+                  onMoveFlow={handleMoveFlow}
+                />
+              )}
+            </div>
+          </div>
+        </div>
+      </main>
+    </>
+  );
+};
+
+export default withAuth(CoursePage, ["教師"]);

--- a/frontend/server/src/app/(teacher)/t/course/[course_id]/page.tsx
+++ b/frontend/server/src/app/(teacher)/t/course/[course_id]/page.tsx
@@ -2,6 +2,9 @@
 import { TeacherHeader } from "@/components/atoms/layout/TeacherHeader";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import withAuth from "@/hocs/withAuth";
 import axios from "@/lib/axios";
 import { BarChart2, Edit, Eye, Loader2 } from "lucide-react";
@@ -447,7 +450,7 @@ export const CoursePage = () => {
   const router = useRouter();
   const course_id = params.course_id as string;
 
-  const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
+  const [_userInfo, setUserInfo] = useState<UserInfo | null>(null);
   const [sessionError, setSessionError] = useState(false);
   const [course, setCourse] = useState<Course | null>(null);
   const [weeks, setWeeks] = useState<Week[]>([]);
@@ -469,6 +472,94 @@ export const CoursePage = () => {
     {} as { [weekId: number]: Content[] },
   );
 
+  const [isAddContentDialogOpen, setIsAddContentDialogOpen] = useState(false);
+  const [weekName, setWeekName] = useState("");
+  const [weekNum, setWeekNum] = useState("");
+  const [order, setOrder] = useState("");
+  const [files, setFiles] = useState<{ file_path: string; file_text: string }[]>([]);
+  const [errorMessage, setErrorMessage] = useState<string[]>([]);
+
+  const validateForm = () => {
+    const errors: string[] = [];
+    if (files.length === 0) {
+      errors.push("登録するコースのフォルダを選択してください。");
+    }
+    if (!weekName) {
+      errors.push("週名を入力してください。");
+    }
+    if (!weekNum) {
+      errors.push("週数を入力してください。");
+    }
+    if (!order) {
+      errors.push("並び順を入力してください。");
+    }
+    setErrorMessage(errors);
+    return errors.length === 0;
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const fileObjects = e.target.files;
+    if (!fileObjects) return;
+
+    const fileForUpload: { file_path: string; file_text: string }[] = [];
+
+    for (const file of Array.from(fileObjects)) {
+      const filePath = (file as File & { webkitRelativePath: string }).webkitRelativePath;
+      const fileReader = new FileReader();
+
+      if (file.type.includes("image")) {
+        fileReader.onload = (e) => {
+          const _result = "";
+          const int8Array = new Uint8Array(e.target?.result as ArrayBuffer);
+          let hexString = "";
+          for (let i = 0; i < int8Array.length; i++) {
+            const str = int8Array[i].toString(16).padStart(2, "0");
+            hexString += `\\x${str}`;
+          }
+          fileForUpload.push({ file_path: filePath, file_text: hexString });
+          setFiles(fileForUpload);
+        };
+        fileReader.readAsArrayBuffer(file);
+      } else {
+        fileReader.onload = (e) => {
+          fileForUpload.push({ file_path: filePath, file_text: e.target?.result as string });
+          setFiles(fileForUpload);
+        };
+        fileReader.readAsText(file);
+      }
+    }
+  };
+
+  const handleRegisterWeek = async () => {
+    if (!validateForm()) return;
+
+    try {
+      const response = await axios.post(
+        "/register_week",
+        {
+          week_name: weekName,
+          week_num: Number.parseInt(weekNum),
+          order: Number.parseInt(order),
+          course_id: course_id,
+          week_files: files,
+        },
+        { withCredentials: true },
+      );
+
+      if (response.data.success) {
+        setIsAddContentDialogOpen(false);
+        // 週一覧を更新
+        const weeksResponse = await axios.get(`/get_weeks/${course_id}`);
+        setWeeks(weeksResponse.data);
+      } else {
+        setErrorMessage([response.data.error_msg]);
+      }
+    } catch (error) {
+      console.error("週の登録に失敗しました:", error);
+      setErrorMessage(["週の登録に失敗しました。"]);
+    }
+  };
+
   useEffect(() => {
     if (!course_id) {
       setLoading(false);
@@ -485,7 +576,6 @@ export const CoursePage = () => {
           if (error.response?.status === 401) {
             setSessionError(true);
           } else {
-            console.log(error.response);
           }
         });
     };
@@ -585,7 +675,6 @@ export const CoursePage = () => {
           console.error(`First content in week ${weekId} not found or course_id missing.`);
         }
       } else {
-        console.log(`No contents found for week ${weekId}. Cannot start week learning.`);
       }
     }
   };
@@ -652,6 +741,28 @@ export const CoursePage = () => {
 
               <div className="mb-6">
                 <div className="flex items-center justify-end space-x-4">
+                  <Button
+                    onClick={() => setIsAddContentDialogOpen(true)}
+                    className="bg-primary hover:bg-primary/90 text-white h-10 px-6 text-base font-medium rounded-xl shadow-sm hover:shadow-md transition-all duration-200 flex items-center gap-2"
+                  >
+                    <svg
+                      className="w-5 h-5"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                      aria-hidden="true"
+                    >
+                      <title>コンテンツ追加アイコン</title>
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth="2"
+                        d="M12 4v16m8-8H4"
+                      />
+                    </svg>
+                    コンテンツを追加
+                  </Button>
                   <div className="flex items-center space-x-2 bg-white p-2 rounded-lg shadow-sm border border-gray-100">
                     <svg className="w-6 h-6 text-primary" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                       <title>カード表示アイコン</title>
@@ -666,11 +777,121 @@ export const CoursePage = () => {
                 </div>
               </div>
 
+              {/* コンテンツ追加ダイアログ */}
+              <Dialog open={isAddContentDialogOpen} onOpenChange={setIsAddContentDialogOpen}>
+                <DialogContent className="sm:max-w-[600px]">
+                  <DialogHeader>
+                    <DialogTitle className="text-2xl font-bold text-gray-800">コンテンツ追加</DialogTitle>
+                  </DialogHeader>
+                  <form
+                    onSubmit={(e) => {
+                      e.preventDefault();
+                      handleRegisterWeek();
+                    }}
+                  >
+                    <div className="grid gap-6 py-6">
+                      {errorMessage.length > 0 && (
+                        <div className="bg-red-50 border border-red-200 text-red-600 p-6 rounded-lg">
+                          <h3 className="font-semibold mb-2">エラーが発生しました</h3>
+                          <ul className="list-disc list-inside space-y-1">
+                            {errorMessage.map((msg) => (
+                              <li key={msg}>{msg}</li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
+
+                      <div className="grid gap-4">
+                        <div className="grid gap-2">
+                          <Label htmlFor="weekName" className="text-base font-medium">
+                            週名
+                          </Label>
+                          <Input
+                            id="weekName"
+                            value={weekName}
+                            onChange={(e) => setWeekName(e.target.value)}
+                            placeholder="例: 線形代数学_第1週"
+                            className="h-12 text-base"
+                            required
+                          />
+                        </div>
+
+                        <div className="grid grid-cols-2 gap-6">
+                          <div className="grid gap-2">
+                            <Label htmlFor="weekNum" className="text-base font-medium">
+                              第○週、第○回
+                            </Label>
+                            <Input
+                              id="weekNum"
+                              type="number"
+                              value={weekNum}
+                              onChange={(e) => setWeekNum(e.target.value)}
+                              placeholder="数値のみを入力"
+                              className="h-12 text-base"
+                              required
+                            />
+                            <p className="text-sm text-gray-500 mt-1">数値のみを入力してください</p>
+                          </div>
+                          <div className="grid gap-2">
+                            <Label htmlFor="order" className="text-base font-medium">
+                              並び順
+                            </Label>
+                            <Input
+                              id="order"
+                              type="number"
+                              value={order}
+                              onChange={(e) => setOrder(e.target.value)}
+                              placeholder="数値のみを入力"
+                              className="h-12 text-base"
+                              required
+                            />
+                            <p className="text-sm text-gray-500 mt-1">昇順でコンテンツが並びます</p>
+                          </div>
+                        </div>
+
+                        <div className="grid gap-2">
+                          <Label htmlFor="files" className="text-base font-medium">
+                            コンテンツファイル
+                          </Label>
+                          <div className="border-2 border-dashed border-gray-300 rounded-lg p-6 text-center">
+                            <Input
+                              id="files"
+                              type="file"
+                              onChange={handleFileChange}
+                              // @ts-ignore
+                              webkitdirectory="true"
+                              // @ts-ignore
+                              directory=""
+                              className="h-12 text-base"
+                              required
+                            />
+                            <p className="text-sm text-gray-500 mt-2">フォルダを選択してください</p>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <DialogFooter className="gap-3">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => setIsAddContentDialogOpen(false)}
+                        className="h-12 text-base"
+                      >
+                        キャンセル
+                      </Button>
+                      <Button type="submit" className="h-12 text-base bg-primary hover:bg-primary/90">
+                        登録
+                      </Button>
+                    </DialogFooter>
+                  </form>
+                </DialogContent>
+              </Dialog>
+
               {isCardView && (
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                   {Object.entries(groupedWeeksByNum)
                     .sort(([numA], [numB]) => Number.parseInt(numA) - Number.parseInt(numB))
-                    .flatMap(([weekNum, weeksInGroup]) =>
+                    .flatMap(([_weekNum, weeksInGroup]) =>
                       weeksInGroup.map((week) => (
                         <WeekSelectCard
                           key={week.week_id}
@@ -683,7 +904,7 @@ export const CoursePage = () => {
                     ).length > 0 ? (
                     Object.entries(groupedWeeksByNum)
                       .sort(([numA], [numB]) => Number.parseInt(numA) - Number.parseInt(numB))
-                      .flatMap(([weekNum, weeksInGroup]) =>
+                      .flatMap(([_weekNum, weeksInGroup]) =>
                         weeksInGroup.map((week) => (
                           <WeekSelectCard
                             key={week.week_id}

--- a/frontend/server/src/app/(teacher)/t/course/[course_id]/page.tsx
+++ b/frontend/server/src/app/(teacher)/t/course/[course_id]/page.tsx
@@ -1,5 +1,4 @@
 "use client";
-import { TeacherHeader } from "@/components/atoms/layout/TeacherHeader";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
@@ -505,14 +504,14 @@ export const CoursePage = () => {
 
     const fileForUpload: { file_path: string; file_text: string }[] = [];
     const fileCount = fileObjects.length;
-    
+
     // フォルダ名を取得（最初のファイルのパスから）
     if (fileCount > 0) {
       const firstFile = fileObjects[0] as File & { webkitRelativePath: string };
-      const folderName = firstFile.webkitRelativePath.split('/')[0];
+      const folderName = firstFile.webkitRelativePath.split("/")[0];
       setSelectedFolderName(folderName);
     }
-    
+
     setSelectedFileCount(fileCount);
 
     for (const file of Array.from(fileObjects)) {
@@ -746,7 +745,6 @@ export const CoursePage = () => {
 
   return (
     <>
-      <TeacherHeader />
       <main className="pt-16">
         <div className="min-h-screen bg-gradient-to-b from-gray-50 to-gray-100">
           <div className="container mx-auto px-4 py-8">
@@ -978,12 +976,7 @@ export const CoursePage = () => {
                       </div>
                     </div>
                     <DialogFooter className="gap-3">
-                      <Button
-                        type="button"
-                        variant="outline"
-                        onClick={handleDialogClose}
-                        className="h-12 text-base"
-                      >
+                      <Button type="button" variant="outline" onClick={handleDialogClose} className="h-12 text-base">
                         キャンセル
                       </Button>
                       <Button type="submit" className="h-12 text-base bg-primary hover:bg-primary/90">

--- a/frontend/server/src/app/(teacher)/t/course/[course_id]/page.tsx
+++ b/frontend/server/src/app/(teacher)/t/course/[course_id]/page.tsx
@@ -4,7 +4,6 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import withAuth from "@/hocs/withAuth";
 import axios from "@/lib/axios";
 import { BarChart2, Edit, Eye, Loader2 } from "lucide-react";
 import { useParams, useRouter } from "next/navigation";
@@ -1041,4 +1040,4 @@ export const CoursePage = () => {
   );
 };
 
-export default withAuth(CoursePage, ["教師"]);
+export default CoursePage;

--- a/frontend/server/src/app/(teacher)/t/course/[course_id]/page.tsx
+++ b/frontend/server/src/app/(teacher)/t/course/[course_id]/page.tsx
@@ -477,6 +477,8 @@ export const CoursePage = () => {
   const [weekNum, setWeekNum] = useState("");
   const [order, setOrder] = useState("");
   const [files, setFiles] = useState<{ file_path: string; file_text: string }[]>([]);
+  const [selectedFileCount, setSelectedFileCount] = useState(0);
+  const [selectedFolderName, setSelectedFolderName] = useState("");
   const [errorMessage, setErrorMessage] = useState<string[]>([]);
 
   const validateForm = () => {
@@ -502,6 +504,16 @@ export const CoursePage = () => {
     if (!fileObjects) return;
 
     const fileForUpload: { file_path: string; file_text: string }[] = [];
+    const fileCount = fileObjects.length;
+    
+    // フォルダ名を取得（最初のファイルのパスから）
+    if (fileCount > 0) {
+      const firstFile = fileObjects[0] as File & { webkitRelativePath: string };
+      const folderName = firstFile.webkitRelativePath.split('/')[0];
+      setSelectedFolderName(folderName);
+    }
+    
+    setSelectedFileCount(fileCount);
 
     for (const file of Array.from(fileObjects)) {
       const filePath = (file as File & { webkitRelativePath: string }).webkitRelativePath;
@@ -548,6 +560,14 @@ export const CoursePage = () => {
 
       if (response.data.success) {
         setIsAddContentDialogOpen(false);
+        // フォームをリセット
+        setWeekName("");
+        setWeekNum("");
+        setOrder("");
+        setFiles([]);
+        setSelectedFileCount(0);
+        setSelectedFolderName("");
+        setErrorMessage([]);
         // 週一覧を更新
         const weeksResponse = await axios.get(`/get_weeks/${course_id}`);
         setWeeks(weeksResponse.data);
@@ -558,6 +578,18 @@ export const CoursePage = () => {
       console.error("週の登録に失敗しました:", error);
       setErrorMessage(["週の登録に失敗しました。"]);
     }
+  };
+
+  const handleDialogClose = () => {
+    setIsAddContentDialogOpen(false);
+    // フォームをリセット
+    setWeekName("");
+    setWeekNum("");
+    setOrder("");
+    setFiles([]);
+    setSelectedFileCount(0);
+    setSelectedFolderName("");
+    setErrorMessage([]);
   };
 
   useEffect(() => {
@@ -754,12 +786,7 @@ export const CoursePage = () => {
                       aria-hidden="true"
                     >
                       <title>コンテンツ追加アイコン</title>
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth="2"
-                        d="M12 4v16m8-8H4"
-                      />
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 4v16m8-8H4" />
                     </svg>
                     コンテンツを追加
                   </Button>
@@ -778,7 +805,7 @@ export const CoursePage = () => {
               </div>
 
               {/* コンテンツ追加ダイアログ */}
-              <Dialog open={isAddContentDialogOpen} onOpenChange={setIsAddContentDialogOpen}>
+              <Dialog open={isAddContentDialogOpen} onOpenChange={handleDialogClose}>
                 <DialogContent className="sm:max-w-[600px]">
                   <DialogHeader>
                     <DialogTitle className="text-2xl font-bold text-gray-800">コンテンツ追加</DialogTitle>
@@ -830,7 +857,6 @@ export const CoursePage = () => {
                               className="h-12 text-base"
                               required
                             />
-                            <p className="text-sm text-gray-500 mt-1">数値のみを入力してください</p>
                           </div>
                           <div className="grid gap-2">
                             <Label htmlFor="order" className="text-base font-medium">
@@ -845,7 +871,6 @@ export const CoursePage = () => {
                               className="h-12 text-base"
                               required
                             />
-                            <p className="text-sm text-gray-500 mt-1">昇順でコンテンツが並びます</p>
                           </div>
                         </div>
 
@@ -853,19 +878,101 @@ export const CoursePage = () => {
                           <Label htmlFor="files" className="text-base font-medium">
                             コンテンツファイル
                           </Label>
-                          <div className="border-2 border-dashed border-gray-300 rounded-lg p-6 text-center">
-                            <Input
-                              id="files"
-                              type="file"
-                              onChange={handleFileChange}
-                              // @ts-ignore
-                              webkitdirectory="true"
-                              // @ts-ignore
-                              directory=""
-                              className="h-12 text-base"
-                              required
-                            />
-                            <p className="text-sm text-gray-500 mt-2">フォルダを選択してください</p>
+                          <div className="border-2 border-dashed border-gray-300 rounded-lg p-6 text-center hover:border-primary/50 transition-colors duration-200">
+                            {selectedFileCount === 0 ? (
+                              <label htmlFor="files" className="flex flex-col items-center space-y-3 cursor-pointer">
+                                <svg
+                                  className="w-12 h-12 text-gray-400"
+                                  fill="none"
+                                  stroke="currentColor"
+                                  viewBox="0 0 24 24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                  aria-hidden="true"
+                                >
+                                  <title>フォルダアイコン</title>
+                                  <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    strokeWidth="2"
+                                    d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-5l-2-2H5a2 2 0 00-2 2z"
+                                  />
+                                </svg>
+                                <div className="text-center">
+                                  <p className="text-sm font-medium text-gray-700 mb-1">フォルダを選択してください</p>
+                                </div>
+                                <Input
+                                  id="files"
+                                  type="file"
+                                  onChange={handleFileChange}
+                                  // @ts-ignore
+                                  webkitdirectory="true"
+                                  // @ts-ignore
+                                  directory=""
+                                  className="h-12 text-base"
+                                  required
+                                />
+                              </label>
+                            ) : (
+                              <div className="flex flex-col items-center space-y-3">
+                                <div className="flex items-center space-x-2 text-green-600">
+                                  <svg
+                                    className="w-8 h-8"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    viewBox="0 0 24 24"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    aria-hidden="true"
+                                  >
+                                    <title>チェックマークアイコン</title>
+                                    <path
+                                      strokeLinecap="round"
+                                      strokeLinejoin="round"
+                                      strokeWidth="2"
+                                      d="M5 13l4 4L19 7"
+                                    />
+                                  </svg>
+                                  <span className="text-lg font-semibold">ファイルが選択されました</span>
+                                </div>
+                                <div className="bg-green-50 border border-green-200 rounded-lg p-4 w-full max-w-md">
+                                  <div className="flex items-center justify-between">
+                                    <div className="flex items-center space-x-2">
+                                      <svg
+                                        className="w-5 h-5 text-green-600"
+                                        fill="none"
+                                        stroke="currentColor"
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        aria-hidden="true"
+                                      >
+                                        <title>フォルダアイコン</title>
+                                        <path
+                                          strokeLinecap="round"
+                                          strokeLinejoin="round"
+                                          strokeWidth="2"
+                                          d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-5l-2-2H5a2 2 0 00-2 2z"
+                                        />
+                                      </svg>
+                                      <span className="font-medium text-gray-900">{selectedFolderName}</span>
+                                    </div>
+                                    <div className="bg-green-100 text-green-800 px-3 py-1 rounded-full text-sm font-medium">
+                                      {selectedFileCount}個のファイル
+                                    </div>
+                                  </div>
+                                </div>
+                                <label htmlFor="files" className="cursor-pointer">
+                                  <Input
+                                    id="files"
+                                    type="file"
+                                    onChange={handleFileChange}
+                                    // @ts-ignore
+                                    webkitdirectory="true"
+                                    // @ts-ignore
+                                    directory=""
+                                    className="hidden"
+                                  />
+                                </label>
+                              </div>
+                            )}
                           </div>
                         </div>
                       </div>
@@ -874,7 +981,7 @@ export const CoursePage = () => {
                       <Button
                         type="button"
                         variant="outline"
-                        onClick={() => setIsAddContentDialogOpen(false)}
+                        onClick={handleDialogClose}
                         className="h-12 text-base"
                       >
                         キャンセル

--- a/frontend/server/src/app/(teacher)/t/home/page.tsx
+++ b/frontend/server/src/app/(teacher)/t/home/page.tsx
@@ -7,7 +7,8 @@ import { Card, CardContent, CardFooter, CardHeader } from "@/components/ui/card"
 import withAuth from "@/hocs/withAuth";
 import { useAuth } from "@/hooks/useAuth";
 import axios from "@/lib/axios";
-import { BookOpen, Calendar, User, Users } from "lucide-react";
+import { BookOpen, Calendar, Loader2, User, Users } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
 type Subject = {
@@ -24,12 +25,25 @@ type SubjectResponse = {
 };
 
 export const TeacherHome = () => {
+  const router = useRouter();
   const { logout } = useAuth();
   const [duringSubjects, setDuringSubjects] = useState<Subject[]>([]);
   const [outsideSubjects, setOutsideSubjects] = useState<Subject[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [userName, setUserName] = useState<string>("");
+  const [loadingButtons, setLoadingButtons] = useState<{ [key: string]: boolean }>({});
+
+  const handleButtonClick = async (buttonId: string, callback: () => Promise<void> | void) => {
+    setLoadingButtons((prev) => ({ ...prev, [buttonId]: true }));
+    try {
+      await callback();
+    } finally {
+      setTimeout(() => {
+        setLoadingButtons((prev) => ({ ...prev, [buttonId]: false }));
+      }, 500);
+    }
+  };
 
   useEffect(() => {
     const fetchUserName = async () => {
@@ -132,8 +146,18 @@ export const TeacherHome = () => {
                             </div>
                           </CardContent>
                           <CardFooter className="p-4 pt-0">
-                            <Button className="w-full bg-gradient-to-r from-primary to-primary/80 hover:from-primary/90 hover:to-primary/70 text-white font-medium py-2 rounded-xl transition-shadow hover:shadow-xl text-sm">
-                              コース情報
+                            <Button
+                              onClick={() =>
+                                handleButtonClick(`course-${item.id}`, () => router.push(`/t/subject/${item.id}`))
+                              }
+                              className="w-full bg-gradient-to-r from-primary to-primary/80 hover:from-primary/90 hover:to-primary/70 text-white font-medium py-2 rounded-xl transition-all text-sm relative"
+                              disabled={loadingButtons[`course-${item.id}`]}
+                            >
+                              {loadingButtons[`course-${item.id}`] ? (
+                                <Loader2 className="w-4 h-4 animate-spin" />
+                              ) : (
+                                "コース情報"
+                              )}
                             </Button>
                           </CardFooter>
                         </Card>
@@ -175,8 +199,18 @@ export const TeacherHome = () => {
                             </div>
                           </CardContent>
                           <CardFooter className="p-4 pt-0">
-                            <Button className="w-full bg-gradient-to-r from-primary to-primary/80 hover:from-primary/90 hover:to-primary/70 text-white font-medium py-2 rounded-xl transition-shadow hover:shadow-xl text-sm">
-                              コース情報
+                            <Button
+                              onClick={() =>
+                                handleButtonClick(`course-${item.id}`, () => router.push(`/t/subject/${item.id}`))
+                              }
+                              className="w-full bg-gradient-to-r from-primary to-primary/80 hover:from-primary/90 hover:to-primary/70 text-white font-medium py-2 rounded-xl transition-all text-sm relative"
+                              disabled={loadingButtons[`course-${item.id}`]}
+                            >
+                              {loadingButtons[`course-${item.id}`] ? (
+                                <Loader2 className="w-4 h-4 animate-spin" />
+                              ) : (
+                                "コース情報"
+                              )}
                             </Button>
                           </CardFooter>
                         </Card>
@@ -186,7 +220,9 @@ export const TeacherHome = () => {
                 )}
               </>
             )}
-            <Button onClick={logout}>ログアウト</Button>
+            <Button onClick={logout} className="mt-4">
+              ログアウト
+            </Button>
           </div>
         </div>
       </main>

--- a/frontend/server/src/app/(teacher)/t/subject/[subject_id]/page.tsx
+++ b/frontend/server/src/app/(teacher)/t/subject/[subject_id]/page.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { TeacherHeader } from "@/components/atoms/layout/TeacherHeader";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader } from "@/components/ui/card";
+import withAuth from "@/hocs/withAuth";
+import { useAuth } from "@/hooks/useAuth";
+import axios from "@/lib/axios";
+import { BarChart2, Calendar, Clock, FileText, Loader2, Users } from "lucide-react";
+import { useParams, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+type Course = {
+  course_id: number;
+  course_name: string;
+  subject_name: string;
+  period: string;
+  username: string;
+  last_accessed?: string;
+};
+
+type ApiResponse = {
+  created: Course[];
+  shared: Course[];
+};
+
+export const SubjectPage = () => {
+  const { logout } = useAuth();
+  const params = useParams();
+  const router = useRouter();
+  const [createdCourses, setCreatedCourses] = useState<Course[]>([]);
+  const [sharedCourses, setSharedCourses] = useState<Course[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [loadingButtons, setLoadingButtons] = useState<{ [key: string]: boolean }>({});
+
+  const handleButtonClick = async (buttonId: string, callback: () => Promise<void> | void) => {
+    setLoadingButtons((prev) => ({ ...prev, [buttonId]: true }));
+    try {
+      await callback();
+    } finally {
+      setTimeout(() => {
+        setLoadingButtons((prev) => ({ ...prev, [buttonId]: false }));
+      }, 500);
+    }
+  };
+
+  useEffect(() => {
+    const fetchCourses = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const response = await axios.get<ApiResponse>(`/get_created_courses/${params.subject_id}`, {
+          withCredentials: true,
+        });
+        if (response.status === 200) {
+          setCreatedCourses(response.data.created || []);
+          setSharedCourses(response.data.shared || []);
+        } else {
+          setError("コース情報の取得に失敗しました");
+        }
+      } catch (_error) {
+        setError("コース情報の取得に失敗しました");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchCourses();
+  }, [params.subject_id]);
+
+  const CourseCard = ({ course }: { course: Course }) => (
+    <Card
+      key={course.course_id}
+      className="hover:shadow-2xl transition-all duration-300 rounded-2xl overflow-hidden group shadow-lg hover:shadow-primary/10"
+    >
+      <CardHeader className="p-4 rounded-t-xl border-b border-primary/10 relative">
+        <div className="absolute top-1/2 right-8 -translate-y-1/2 opacity-10 text-secondary/50 transform scale-[2.5] pointer-events-none">
+          <FileText className="w-10 h-10" />
+        </div>
+        <div className="flex items-start justify-between">
+          <div className="pl-2">
+            <p className="text-xs text-gray-500 mb-0.5">コース名</p>
+            <div className="flex items-center gap-2">
+              <h3 className="text-xl font-semibold text-gray-800">{course.course_name}</h3>
+              <span className="bg-blue-100 text-blue-800 text-xs font-medium px-2 py-0.5 rounded-full">必修</span>
+              <span className="bg-purple-100 text-purple-800 text-xs font-medium px-2 py-0.5 rounded-full">基礎</span>
+            </div>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="p-4 space-y-3">
+        <div className="flex items-center gap-3 bg-white/80 rounded-xl p-3 shadow-inner">
+          <Users className="text-primary w-4 h-4" />
+          <span className="text-sm text-neutral-700 font-medium">作成者: {course.username}</span>
+        </div>
+        <div className="flex items-center gap-3 bg-white/80 rounded-xl p-3 shadow-inner">
+          <Calendar className="text-primary w-4 h-4" />
+          <span className="text-sm text-neutral-700 font-medium">開講期間: {course.period}</span>
+        </div>
+        <div className="flex items-center gap-3 bg-white/80 rounded-xl p-3 shadow-inner">
+          <Clock className="text-primary w-4 h-4" />
+          <span className="text-sm text-neutral-700 font-medium">
+            最終アクセス:{" "}
+            {course.last_accessed ? new Date(course.last_accessed).toLocaleString("ja-JP") : "アクセス履歴なし"}
+          </span>
+        </div>
+      </CardContent>
+      <CardFooter className="p-4 pt-0">
+        <div className="w-full flex gap-3">
+          <Button
+            className="flex-1 bg-gradient-to-r from-primary to-primary/80 hover:from-primary/90 hover:to-primary/70 text-white font-medium py-2 rounded-xl transition-shadow hover:shadow-xl text-sm flex items-center justify-center gap-2"
+            onClick={() =>
+              handleButtonClick(`course-${course.course_id}`, () => router.push(`/t/course/${course.course_id}`))
+            }
+            disabled={loadingButtons[`course-${course.course_id}`]}
+          >
+            {loadingButtons[`course-${course.course_id}`] ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <>
+                <FileText className="w-4 h-4" />
+                コース詳細
+              </>
+            )}
+          </Button>
+          <Button
+            variant="outline"
+            className="flex-1 border border-primary/20 hover:bg-primary/5 text-primary font-medium py-2 rounded-xl transition-all text-sm flex items-center justify-center gap-2 bg-white"
+            onClick={() => handleButtonClick(`status-${course.course_id}`, () => {})}
+            disabled={loadingButtons[`status-${course.course_id}`]}
+          >
+            {loadingButtons[`status-${course.course_id}`] ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <>
+                <BarChart2 className="w-4 h-4" />
+                学習状況照会
+              </>
+            )}
+          </Button>
+        </div>
+      </CardFooter>
+    </Card>
+  );
+
+  return (
+    <>
+      <TeacherHeader />
+      <main className="pt-12">
+        <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100">
+          <div className="container mx-auto px-8 py-12 max-w-7xl">
+            <div className="flex items-center justify-between mb-12">
+              <h2 className="text-3xl font-bold text-gray-800">コース一覧</h2>
+              <div className="flex items-center gap-3 bg-white/80 px-4 py-2 rounded-xl shadow-sm" />
+            </div>
+            {isLoading ? (
+              <div className="text-center py-8">読み込み中...</div>
+            ) : error ? (
+              <div className="text-center py-8 text-red-500">{error}</div>
+            ) : (
+              <>
+                <div className="mb-12">
+                  <div className="flex items-center gap-3 mb-6">
+                    <h3 className="text-2xl font-semibold text-gray-800">共有中のコース</h3>
+                    <span className="bg-blue-100 text-blue-800 text-sm font-medium px-3 py-1 rounded-full">共有中</span>
+                  </div>
+                  {sharedCourses.length > 0 ? (
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+                      {sharedCourses.map((course) => (
+                        <CourseCard key={course.course_id} course={course} />
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="text-center py-8 text-gray-500 bg-white rounded-xl shadow-sm">
+                      共有中のコースはありません
+                    </div>
+                  )}
+                </div>
+
+                <div>
+                  <div className="flex items-center gap-3 mb-6">
+                    <h3 className="text-2xl font-semibold text-gray-800">作成したコース</h3>
+                    <span className="bg-green-100 text-green-800 text-sm font-medium px-3 py-1 rounded-full">
+                      作成済み
+                    </span>
+                  </div>
+                  {createdCourses.length > 0 ? (
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+                      {createdCourses.map((course) => (
+                        <CourseCard key={course.course_id} course={course} />
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="text-center py-8 text-gray-500 bg-white rounded-xl shadow-sm">
+                      作成したコースはありません
+                    </div>
+                  )}
+                </div>
+              </>
+            )}
+            <Button onClick={logout} className="mt-4">
+              ログアウト
+            </Button>
+          </div>
+        </div>
+      </main>
+    </>
+  );
+};
+
+export default withAuth(SubjectPage);

--- a/frontend/server/src/app/(teacher)/t/subject/[subject_id]/page.tsx
+++ b/frontend/server/src/app/(teacher)/t/subject/[subject_id]/page.tsx
@@ -1,6 +1,4 @@
 "use client";
-
-import { TeacherHeader } from "@/components/atoms/layout/TeacherHeader";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter, CardHeader } from "@/components/ui/card";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
@@ -210,7 +208,6 @@ export const SubjectPage = () => {
 
   return (
     <>
-      <TeacherHeader />
       <main className="pt-12">
         <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100">
           <div className="container mx-auto px-8 py-12 max-w-7xl">

--- a/frontend/server/src/app/(teacher)/t/subject/[subject_id]/page.tsx
+++ b/frontend/server/src/app/(teacher)/t/subject/[subject_id]/page.tsx
@@ -4,7 +4,6 @@ import { Card, CardContent, CardFooter, CardHeader } from "@/components/ui/card"
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import withAuth from "@/hocs/withAuth";
 import { useAuth } from "@/hooks/useAuth";
 import axios from "@/lib/axios";
 import { BarChart2, Calendar, Clock, FileText, Loader2, Users } from "lucide-react";
@@ -489,4 +488,4 @@ export const SubjectPage = () => {
   );
 };
 
-export default withAuth(SubjectPage);
+export default SubjectPage;

--- a/frontend/server/src/app/(teacher)/t/subject/[subject_id]/page.tsx
+++ b/frontend/server/src/app/(teacher)/t/subject/[subject_id]/page.tsx
@@ -3,6 +3,9 @@
 import { TeacherHeader } from "@/components/atoms/layout/TeacherHeader";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter, CardHeader } from "@/components/ui/card";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import withAuth from "@/hocs/withAuth";
 import { useAuth } from "@/hooks/useAuth";
 import axios from "@/lib/axios";
@@ -33,6 +36,26 @@ export const SubjectPage = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [loadingButtons, setLoadingButtons] = useState<{ [key: string]: boolean }>({});
+  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
+
+  // コース作成用の状態
+  const [courseName, setCourseName] = useState("");
+  const [startDate, setStartDate] = useState({
+    year: "",
+    month: "",
+    day: "",
+    hour: "",
+    minute: "",
+  });
+  const [endDate, setEndDate] = useState({
+    year: "",
+    month: "",
+    day: "",
+    hour: "",
+    minute: "",
+  });
+  const [weeks, setWeeks] = useState<number>(1);
+  const [isCreating, setIsCreating] = useState(false);
 
   const handleButtonClick = async (buttonId: string, callback: () => Promise<void> | void) => {
     setLoadingButtons((prev) => ({ ...prev, [buttonId]: true }));
@@ -68,6 +91,47 @@ export const SubjectPage = () => {
 
     fetchCourses();
   }, [params.subject_id]);
+
+  // 日時を結合する関数
+  const combineDateTime = (date: { year: string; month: string; day: string; hour: string; minute: string }) => {
+    const { year, month, day, hour, minute } = date;
+    return `${year}-${month.padStart(2, "0")}-${day.padStart(2, "0")}T${hour.padStart(2, "0")}:${minute.padStart(2, "0")}:00`;
+  };
+
+  const handleCreateCourse = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsCreating(true);
+
+    try {
+      const response = await axios.post(
+        "/create_course",
+        {
+          subject_id: params.subject_id,
+          course_name: courseName,
+          start_date_time: combineDateTime(startDate),
+          end_date_time: combineDateTime(endDate),
+          weeks: weeks,
+        },
+        { withCredentials: true },
+      );
+
+      if (response.data.success) {
+        setIsCreateDialogOpen(false);
+        // コース一覧を更新
+        const coursesResponse = await axios.get<ApiResponse>(`/get_created_courses/${params.subject_id}`, {
+          withCredentials: true,
+        });
+        if (coursesResponse.status === 200) {
+          setCreatedCourses(coursesResponse.data.created || []);
+          setSharedCourses(coursesResponse.data.shared || []);
+        }
+      }
+    } catch (error) {
+      console.error("コースの作成に失敗しました:", error);
+    } finally {
+      setIsCreating(false);
+    }
+  };
 
   const CourseCard = ({ course }: { course: Course }) => (
     <Card
@@ -152,8 +216,227 @@ export const SubjectPage = () => {
           <div className="container mx-auto px-8 py-12 max-w-7xl">
             <div className="flex items-center justify-between mb-12">
               <h2 className="text-3xl font-bold text-gray-800">コース一覧</h2>
-              <div className="flex items-center gap-3 bg-white/80 px-4 py-2 rounded-xl shadow-sm" />
+              <div className="flex items-center gap-3">
+                <Button
+                  onClick={() => setIsCreateDialogOpen(true)}
+                  className="bg-primary hover:bg-primary/90 text-white"
+                >
+                  <svg
+                    className="w-5 h-5"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                    aria-hidden="true"
+                  >
+                    <title>コース追加アイコン</title>
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 4v16m8-8H4" />
+                  </svg>
+                  コースを追加
+                </Button>
+              </div>
             </div>
+
+            {/* コース作成ダイアログ */}
+            <Dialog open={isCreateDialogOpen} onOpenChange={setIsCreateDialogOpen}>
+              <DialogContent className="sm:max-w-[600px]">
+                <DialogHeader>
+                  <DialogTitle className="text-2xl font-bold text-gray-800">新規コース作成</DialogTitle>
+                </DialogHeader>
+                <form onSubmit={handleCreateCourse}>
+                  <div className="grid gap-6 py-6">
+                    <div className="grid gap-4">
+                      <div className="grid gap-2">
+                        <Label htmlFor="courseName" className="text-base font-medium">
+                          コース名
+                        </Label>
+                        <Input
+                          id="courseName"
+                          value={courseName}
+                          onChange={(e) => setCourseName(e.target.value)}
+                          className="h-12 text-base"
+                          placeholder="コース名を入力してください"
+                          required
+                        />
+                      </div>
+
+                      <div className="grid gap-2">
+                        <Label className="text-base font-medium">開始日時</Label>
+                        <div className="grid grid-cols-5 gap-3">
+                          <div className="grid gap-1">
+                            <Input
+                              type="number"
+                              placeholder="年"
+                              value={startDate.year}
+                              onChange={(e) => setStartDate((prev) => ({ ...prev, year: e.target.value }))}
+                              className="h-12 text-base"
+                              required
+                            />
+                            <p className="text-xs text-gray-500">年</p>
+                          </div>
+                          <div className="grid gap-1">
+                            <Input
+                              type="number"
+                              placeholder="月"
+                              min="1"
+                              max="12"
+                              value={startDate.month}
+                              onChange={(e) => setStartDate((prev) => ({ ...prev, month: e.target.value }))}
+                              className="h-12 text-base"
+                              required
+                            />
+                            <p className="text-xs text-gray-500">月</p>
+                          </div>
+                          <div className="grid gap-1">
+                            <Input
+                              type="number"
+                              placeholder="日"
+                              min="1"
+                              max="31"
+                              value={startDate.day}
+                              onChange={(e) => setStartDate((prev) => ({ ...prev, day: e.target.value }))}
+                              className="h-12 text-base"
+                              required
+                            />
+                            <p className="text-xs text-gray-500">日</p>
+                          </div>
+                          <div className="grid gap-1">
+                            <Input
+                              type="number"
+                              placeholder="時"
+                              min="0"
+                              max="23"
+                              value={startDate.hour}
+                              onChange={(e) => setStartDate((prev) => ({ ...prev, hour: e.target.value }))}
+                              className="h-12 text-base"
+                              required
+                            />
+                            <p className="text-xs text-gray-500">時</p>
+                          </div>
+                          <div className="grid gap-1">
+                            <Input
+                              type="number"
+                              placeholder="分"
+                              min="0"
+                              max="59"
+                              value={startDate.minute}
+                              onChange={(e) => setStartDate((prev) => ({ ...prev, minute: e.target.value }))}
+                              className="h-12 text-base"
+                              required
+                            />
+                            <p className="text-xs text-gray-500">分</p>
+                          </div>
+                        </div>
+                      </div>
+
+                      <div className="grid gap-2">
+                        <Label className="text-base font-medium">終了日時</Label>
+                        <div className="grid grid-cols-5 gap-3">
+                          <div className="grid gap-1">
+                            <Input
+                              type="number"
+                              placeholder="年"
+                              value={endDate.year}
+                              onChange={(e) => setEndDate((prev) => ({ ...prev, year: e.target.value }))}
+                              className="h-12 text-base"
+                              required
+                            />
+                            <p className="text-xs text-gray-500">年</p>
+                          </div>
+                          <div className="grid gap-1">
+                            <Input
+                              type="number"
+                              placeholder="月"
+                              min="1"
+                              max="12"
+                              value={endDate.month}
+                              onChange={(e) => setEndDate((prev) => ({ ...prev, month: e.target.value }))}
+                              className="h-12 text-base"
+                              required
+                            />
+                            <p className="text-xs text-gray-500">月</p>
+                          </div>
+                          <div className="grid gap-1">
+                            <Input
+                              type="number"
+                              placeholder="日"
+                              min="1"
+                              max="31"
+                              value={endDate.day}
+                              onChange={(e) => setEndDate((prev) => ({ ...prev, day: e.target.value }))}
+                              className="h-12 text-base"
+                              required
+                            />
+                            <p className="text-xs text-gray-500">日</p>
+                          </div>
+                          <div className="grid gap-1">
+                            <Input
+                              type="number"
+                              placeholder="時"
+                              min="0"
+                              max="23"
+                              value={endDate.hour}
+                              onChange={(e) => setEndDate((prev) => ({ ...prev, hour: e.target.value }))}
+                              className="h-12 text-base"
+                              required
+                            />
+                            <p className="text-xs text-gray-500">時</p>
+                          </div>
+                          <div className="grid gap-1">
+                            <Input
+                              type="number"
+                              placeholder="分"
+                              min="0"
+                              max="59"
+                              value={endDate.minute}
+                              onChange={(e) => setEndDate((prev) => ({ ...prev, minute: e.target.value }))}
+                              className="h-12 text-base"
+                              required
+                            />
+                            <p className="text-xs text-gray-500">分</p>
+                          </div>
+                        </div>
+                      </div>
+
+                      <div className="grid gap-2">
+                        <Label htmlFor="weeks" className="text-base font-medium">
+                          週数
+                        </Label>
+                        <Input
+                          id="weeks"
+                          type="number"
+                          min="1"
+                          value={weeks}
+                          onChange={(e) => setWeeks(Number.parseInt(e.target.value))}
+                          className="h-12 text-base"
+                          placeholder="週数を入力してください"
+                          required
+                        />
+                        <p className="text-sm text-gray-500">コースの週数を設定してください</p>
+                      </div>
+                    </div>
+                  </div>
+                  <DialogFooter className="gap-3">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => setIsCreateDialogOpen(false)}
+                      className="h-12 text-base"
+                    >
+                      キャンセル
+                    </Button>
+                    <Button
+                      type="submit"
+                      disabled={isCreating}
+                      className="h-12 text-base bg-primary hover:bg-primary/90"
+                    >
+                      {isCreating ? "作成中..." : "作成"}
+                    </Button>
+                  </DialogFooter>
+                </form>
+              </DialogContent>
+            </Dialog>
+
             {isLoading ? (
               <div className="text-center py-8">読み込み中...</div>
             ) : error ? (

--- a/frontend/server/src/app/globals.css
+++ b/frontend/server/src/app/globals.css
@@ -134,9 +134,9 @@ html[data-theme="theme3"] {
 }
 
 html[data-theme="theme4"] {
-	--primary: oklch(88% 0.16 105);         /* より黄色らしい、フレッシュな色 */
-	--primary-foreground: oklch(20% 0 0);   /* 黒に近い文字色 */
-	--secondary: oklch(95% 0.08 105);       /* 明るめサブカラー */
+	--primary: oklch(88% 0.16 105); /* より黄色らしい、フレッシュな色 */
+	--primary-foreground: oklch(20% 0 0); /* 黒に近い文字色 */
+	--secondary: oklch(95% 0.08 105); /* 明るめサブカラー */
 	--secondary-foreground: oklch(30% 0 0);
 }
 

--- a/frontend/server/src/router/router.ts
+++ b/frontend/server/src/router/router.ts
@@ -10,7 +10,7 @@ export const roleRedirectMap: { [key: string]: string } = {
 // kind_nameに基づいて、各ロールのアクセス可能なページの定義
 export const pageAccessRules: { [key: string]: string[] } = {
   管理者: ["/admin/home"],
-  教師: ["/t/home"],
+  教師: ["/t/home", "/t/subject", "/t/course", "/t/weekflows"],
   学生: ["/home", "/weekflows", "/course"],
   テスト: ["/home", "/weekflows", "/course"],
 };
@@ -18,6 +18,7 @@ export const pageAccessRules: { [key: string]: string[] } = {
 // 特定のパスプレフィックスに対して、アクセスを許可するkind_nameのリストを定義
 export const protectedRoutesWithRoles: { [pathPrefix: string]: string[] } = {
   "/admin": ["管理者"],
+  "/t": ["教師"],
   "/teacher": ["教師", "管理者"],
   "/student": ["テスト", "学生", "教師", "管理者"],
 };


### PR DESCRIPTION
## issue
Relate #37 
Closes #38 
## 目的
教師用のコース選択画面・コース選択画面の作成
## 行ったこと
教師用のコース選択画面・コース選択画面の作成
コンテンツ登録機能
コース登録機能の作成
## 実際に試してみるには
教師用でログイン→科目選択→コース選択→コンテンツ選択のページ
コース選択ページではコンテンツ登録の実行
コンテンツ選択ページではコンテンツ登録の実行
### その他
backendで一度最新版を落としてください