### PR TITLE
Lefthookの設定周りを修正

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,25 +1,8 @@
-# lefthook.yml
 pre-commit:
+  parallel: true
   commands:
-    check: # コマンド名はそのまま "check" を使用
+    check:
       glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
-      glob_ignore:
-        - "public/libs/MathJax/**/*"
-        - "src/components/ui/**/*"
-      run: |
-        # LEFTHOOK_FILES 環境変数はLefthookによって設定され、
-        # ステージングされていて、かつglobパターンに一致するファイルリスト（改行区切り）を含みます。
-        # 処理対象のファイルがない場合は何もしないで終了します。
-        if [ -z "$LEFTHOOK_FILES" ]; then
-          exit 0
-        fi
-
-        # 'set -e' でコマンドが失敗したら直ちにスクリプトを終了させます。
-        set -e
-
-        # LEFTHOOK_FILES をnull区切りに変換し、xargs を使って biome コマンドに渡します。
-        # '--' はbiomeコマンドのオプションの終わりを示し、続く引数がファイルパスであることを明示します。
-        echo "$LEFTHOOK_FILES" | tr '\n' '\0' | xargs -0 --no-run-if-empty npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --
-
-        # biome がファイルを変更した場合、それらを再度ステージングします。
-        echo "$LEFTHOOK_FILES" | tr '\n' '\0' | xargs -0 --no-run-if-empty git add
+      exclude: "^(public/libs/MathJax/|src/components/ui/).*$"
+      run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true -- {staged_files}
+      stage_fixed: true

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"version": "0.1.0",
 	"private": true,
 	"scripts": {
+		"prepare": "lefthook install",
 		"lint": "biome check .",
 		"format": "biome check . --write --unsafe"
 	},


### PR DESCRIPTION
Lefthook周りの設定を修正しました

- glob_ignore -> exclude
- runの内容を簡潔に修正
  - staged_filesを使うように変更
  - stage_fixed: true で処理後にgit addする

prepareにlefthook installを追加して，npm installとかするときに自動でlefthoookを有効にするように変更